### PR TITLE
Stop display of deprecated datetime_stored attribute and usage of the same all places

### DIFF
--- a/app/views/files/_file_info.html.erb
+++ b/app/views/files/_file_info.html.erb
@@ -8,10 +8,6 @@
     <td><%= file.original_filename %></td>
   </tr>
   <tr>
-    <th>Stored date</th>
-    <td><%= file.datetime_stored.present? ? Time.zone.parse(file.datetime_stored).strftime(date_format) : '-' %></td>
-  </tr>
-  <tr>
     <th>Uploaded date</th>
     <td><%= file.datetime_uploaded.present? ? Time.zone.parse(file.datetime_uploaded).strftime(date_format) : '-' %></td>
   </tr>

--- a/spec/requests/files_controller_spec.rb
+++ b/spec/requests/files_controller_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe FilesController, type: :request do
     let(:file) do
       Uploadcare::File.new(
         "datetime_removed": nil,
-        "datetime_stored": '2018-11-26T12:49:10.477888Z',
         "datetime_uploaded": '2018-11-26T12:49:09.945335Z',
         "image_info": {
           "color_mode": 'RGB',

--- a/spec/requests/files_groups_controller_spec.rb
+++ b/spec/requests/files_groups_controller_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe FileGroupsController, type: :request do
       {
         'id' => 'd476f4c9-44a9-4670-88a5-c3cf5d26b6c2~20',
         'datetime_created' => '2021-07-16T11:03:01.182939Z',
-        'datetime_stored' => '2021-07-30T10:26:47.294442Z',
         'files_count' => 20,
         'cdn_url' => 'https://ucarecdn.com/d476f4c9-44a9-4670-88a5-c3cf5d26b6c2~20/',
         'url' => 'https://api.uploadcare.com/groups/d476f4c9-44a9-4670-88a5-c3cf5d26b6c2~20/',

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe PostsController, type: :request do
       {
         'id' => 'd476f4c9-44a9-4670-88a5-c3cf5d26b6c2~20',
         'datetime_created' => '2021-07-16T11:03:01.182939Z',
-        'datetime_stored' => '2021-07-30T10:26:47.294442Z',
         'files_count' => 20,
         'cdn_url' => 'https://ucarecdn.com/d476f4c9-44a9-4670-88a5-c3cf5d26b6c2~20/',
         'url' => 'https://api.uploadcare.com/groups/d476f4c9-44a9-4670-88a5-c3cf5d26b6c2~20/',


### PR DESCRIPTION
## Description

Stop display of deprecated datetime_stored attribute and usage of the same all places

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
