### PR TITLE
Modernize examples app with Tailwind

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,11 +62,12 @@ jobs:
           node-version: 22
           package-manager-cache: false
 
-      - name: Install and build JS assets
+      - name: Install and build assets
         run: |
           corepack enable
           pnpm install --frozen-lockfile
           pnpm build
+          bundle exec rails tailwindcss:build
 
       - name: Ensure gems are available for Playwright compatibility check
         run: bundle check || bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "propshaft"
 
 gem "turbo-rails"
 gem "jsbundling-rails"
+gem "tailwindcss-rails", "~> 4.4"
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem "jbuilder"
@@ -65,8 +66,8 @@ end
 gem "tzinfo-data", platforms: %i[windows mswin jruby]
 
 # Uploadcare-rails provides unified API interface to Uploadcare API
-gem "uploadcare-rails", github: "uploadcare/uploadcare-rails", branch: "5-0-stable"
-gem "uploadcare-ruby", github: "uploadcare/uploadcare-ruby", branch: "5-0-stable"
+gem "uploadcare-rails", "5.0.0.rc1"
+gem "uploadcare-ruby", "5.0.0.rc1"
 
 # Use MongoDB for the database, with Mongoid as the ODM
 gem "mongoid", "< 10"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,3 @@
-GIT
-  remote: https://github.com/uploadcare/uploadcare-rails.git
-  revision: 01c73621db5d138f597e5400308f8646209c0aea
-  branch: 5-0-stable
-  specs:
-    uploadcare-rails (5.0.0.rc1)
-      rails (>= 7.2)
-      uploadcare-ruby (>= 5.0.0.rc1)
-
-GIT
-  remote: https://github.com/uploadcare/uploadcare-ruby.git
-  revision: 181cdb32a3c7535e6f94eaed4b9939297c1a9d81
-  branch: 5-0-stable
-  specs:
-    uploadcare-ruby (5.0.0.rc1)
-      addressable (~> 2.8)
-      faraday (~> 2.14)
-      faraday-multipart (~> 1.0)
-      mime-types (~> 3.7)
-      zeitwerk (~> 2.7)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -207,7 +186,7 @@ GEM
     multipart-post (2.4.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -368,6 +347,13 @@ GEM
     sexp_processor (4.17.5)
     spring (4.4.2)
     stringio (3.2.0)
+    tailwindcss-rails (4.4.0)
+      railties (>= 7.0.0)
+      tailwindcss-ruby (~> 4.0)
+    tailwindcss-ruby (4.2.2-aarch64-linux-gnu)
+    tailwindcss-ruby (4.2.2-arm64-darwin)
+    tailwindcss-ruby (4.2.2-x86_64-darwin)
+    tailwindcss-ruby (4.2.2-x86_64-linux-gnu)
     thor (1.5.0)
     timeout (0.6.1)
     tsort (0.2.0)
@@ -379,6 +365,15 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
+    uploadcare-rails (5.0.0.rc1)
+      rails (>= 7.2)
+      uploadcare-ruby (>= 5.0.0.rc1)
+    uploadcare-ruby (5.0.0.rc1)
+      addressable (~> 2.8)
+      faraday (~> 2.14)
+      faraday-multipart (~> 1.0)
+      mime-types (~> 3.7)
+      zeitwerk (~> 2.7)
     uri (1.1.1)
     useragent (0.16.11)
     web-console (4.3.0)
@@ -425,10 +420,11 @@ DEPENDENCIES
   rspec-rails
   rubocop-rails-omakase
   spring
+  tailwindcss-rails (~> 4.4)
   turbo-rails
   tzinfo-data
-  uploadcare-rails!
-  uploadcare-ruby!
+  uploadcare-rails (= 5.0.0.rc1)
+  uploadcare-ruby (= 5.0.0.rc1)
   web-console
 
 RUBY VERSION

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
 web: mise exec -- ruby bin/rails server
 js: mise exec -- pnpm build --watch
+css: mise exec -- ruby bin/rails tailwindcss:watch

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Uploadcare Rails Example app
 
 This example project demonstrates the uploadcare-rails capabilities.
-The app is pinned to the `5-0-stable` branches of `uploadcare/uploadcare-rails` and `uploadcare/uploadcare-ruby`, targets Ruby `>= 4.0.0`, runs Rails `8.1.x`, and uses pnpm-managed Hotwire assets.
+The app uses the `5.0.0.rc1` prerelease gems for `uploadcare-rails` and `uploadcare-ruby`, targets Ruby `>= 4.0.0`, runs Rails `8.1.x`, and uses Hotwire with Tailwind CSS.
 
 * [Installation](#installation)
   * [Requirements](#requirements)
@@ -51,6 +51,7 @@ $ cd uploadcare-rails-example
 $ mise exec -- bundle install
 $ mise exec -- pnpm install
 $ mise exec -- pnpm build
+$ mise exec -- ruby bin/rails tailwindcss:build
 $ mise exec -- ruby bin/rails db:prepare
 $ mise exec -- ruby bin/rails db:migrate
 ```
@@ -68,7 +69,7 @@ Start the server and the pnpm watcher together:
 $ ./bin/dev
 ```
 
-`bin/dev` runs Rails plus `pnpm build --watch`, so Hotwire assets stay current while you work.
+`bin/dev` runs Rails plus `pnpm build --watch` and `tailwindcss:watch`, so Hotwire and Tailwind assets stay current while you work.
 
 ![Application is available](./references/application-up-in-browser.png)
 
@@ -177,7 +178,7 @@ The example app uploads files in three ways: local file upload via the Upload AP
 ---
 **NOTE**
 
-The app now uses the current `5-0-stable` branch APIs. The Post and Comment forms render the v1 Uploadcare File Uploader Web Components directly with `<uc-form-input>`, `<uc-config>`, `<uc-file-uploader-regular>`, and `<uc-upload-ctx-provider>`. Group uploads submit a single Uploadcare group URL that matches `has_uploadcare_files`. Manual API actions in controllers use `Uploadcare::Rails.client`, and the conversion examples use the raw REST parity layer where exact path control is needed.
+The app now uses the current `5.0.0.rc1` prerelease APIs. The Post and Comment forms render the v1 Uploadcare File Uploader Web Components directly with `<uc-form-input>`, `<uc-config>`, `<uc-file-uploader-regular>`, and `<uc-upload-ctx-provider>`. Group uploads submit a single Uploadcare group URL that matches `has_uploadcare_files`. Manual API actions in controllers use `Uploadcare::Rails.client`, and the conversion examples use the raw REST parity layer where exact path control is needed.
 
 ---
 

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,0 +1,236 @@
+@import "tailwindcss";
+
+@layer base {
+  body {
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
+
+  h1 {
+    @apply mb-2 text-2xl font-semibold tracking-normal text-slate-950;
+  }
+
+  h2 {
+    @apply text-xl font-semibold tracking-normal text-slate-950;
+  }
+
+  h3 {
+    @apply text-lg font-semibold tracking-normal text-slate-950;
+  }
+
+  h4 {
+    @apply text-base font-semibold tracking-normal text-slate-950;
+  }
+
+  a {
+    @apply text-slate-900 underline-offset-4 hover:text-slate-700 hover:underline;
+  }
+
+  code {
+    @apply rounded bg-slate-100 px-1.5 py-0.5 text-sm text-slate-900;
+  }
+}
+
+@layer components {
+  .page-lede {
+    @apply mb-5 max-w-3xl text-sm leading-6 text-slate-600;
+  }
+
+  .card {
+    @apply overflow-hidden rounded-md border border-slate-200 bg-white shadow-sm;
+  }
+
+  .card-body {
+    @apply p-5;
+  }
+
+  .card-title {
+    @apply mb-3 font-semibold text-slate-950;
+  }
+
+  .list-group {
+    @apply divide-y divide-slate-200 rounded-md border border-slate-200 bg-white;
+  }
+
+  .list-group-flush {
+    @apply rounded-none border-x-0 border-b-0;
+  }
+
+  .list-group-item {
+    @apply p-4 text-sm text-slate-700;
+  }
+
+  .btn {
+    @apply inline-flex items-center justify-center rounded-md border border-transparent px-3 py-2 text-sm font-medium no-underline transition focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50;
+  }
+
+  .btn-sm {
+    @apply px-2.5 py-1.5 text-xs;
+  }
+
+  .btn-primary {
+    @apply bg-slate-950 text-white hover:bg-slate-800 hover:text-white;
+  }
+
+  .btn-secondary {
+    @apply border-slate-300 bg-white text-slate-800 hover:bg-slate-100 hover:text-slate-950;
+  }
+
+  .btn-danger {
+    @apply bg-rose-600 text-white hover:bg-rose-700 hover:text-white;
+  }
+
+  .btn-outline-primary {
+    @apply border-slate-950 bg-white text-slate-950 hover:bg-slate-950 hover:text-white;
+  }
+
+  .btn-group {
+    @apply flex flex-wrap items-center gap-2;
+  }
+
+  .button_to {
+    @apply inline-flex;
+  }
+
+  .badge {
+    @apply inline-flex items-center rounded-md px-2 py-1 text-xs font-medium no-underline;
+  }
+
+  .badge-secondary {
+    @apply bg-slate-100 text-slate-700;
+  }
+
+  .badge-info {
+    @apply bg-sky-100 text-sky-800;
+  }
+
+  .form-control,
+  .custom-file-input,
+  input[type="text"],
+  input[type="url"],
+  input[type="email"],
+  input[type="number"],
+  input[type="file"],
+  textarea,
+  select {
+    @apply mt-1 block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-950 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200;
+  }
+
+  label,
+  .form-check-label {
+    @apply text-sm font-medium text-slate-700;
+  }
+
+  .form-check {
+    @apply flex items-center gap-2;
+  }
+
+  .form-check-input,
+  input[type="checkbox"],
+  input[type="radio"] {
+    @apply h-4 w-4 rounded border-slate-300 text-slate-950 focus:ring-slate-400;
+  }
+
+  .custom-file-label {
+    @apply mt-2 block text-xs text-slate-500;
+  }
+
+  .table {
+    @apply w-full divide-y divide-slate-200 text-left text-sm;
+  }
+
+  .table th {
+    @apply bg-slate-50 px-3 py-2 font-semibold text-slate-700;
+  }
+
+  .table td {
+    @apply px-3 py-2 text-slate-700;
+  }
+
+  .row {
+    @apply grid gap-4;
+  }
+
+  .row-cols-1 {
+    @apply grid-cols-1;
+  }
+
+  .row-cols-lg-2 {
+    @apply lg:grid-cols-2;
+  }
+
+  .col {
+    @apply min-w-0;
+  }
+
+  .text-body-secondary {
+    @apply text-slate-500;
+  }
+
+  .text-place {
+    @apply min-w-0;
+  }
+
+  .text-truncate {
+    @apply truncate;
+  }
+
+  .d-flex {
+    @apply flex;
+  }
+
+  .d-inline {
+    @apply inline-flex;
+  }
+
+  .justify-content-between {
+    @apply justify-between;
+  }
+
+  .align-items-center {
+    @apply items-center;
+  }
+
+  .flex-grow-1 {
+    @apply flex-1;
+  }
+
+  .flex-shrink-0 {
+    @apply flex-shrink-0;
+  }
+
+  .h-100 {
+    @apply h-full;
+  }
+
+  .w-100 {
+    @apply w-full;
+  }
+
+  .small {
+    @apply text-sm;
+  }
+
+  .h4 {
+    @apply text-base font-semibold;
+  }
+
+  .h5 {
+    @apply text-sm font-semibold;
+  }
+
+  .h1 {
+    @apply text-2xl font-semibold;
+  }
+
+  .d-block {
+    @apply block;
+  }
+
+  .table-responsive {
+    @apply w-full overflow-x-auto;
+  }
+
+  .g-3 {
+    @apply gap-3;
+  }
+}

--- a/app/controllers/examples_controller.rb
+++ b/app/controllers/examples_controller.rb
@@ -5,6 +5,7 @@ class ExamplesController < ApplicationController
     @example_groups = [
       {
         title: "Core API operations",
+        description: "Inspect project data, manage files, create groups, and exercise upload flows.",
         links: [
           [ "Project info", project_path ],
           [ "Files", files_path ],
@@ -15,6 +16,7 @@ class ExamplesController < ApplicationController
       },
       {
         title: "Conversions and add-ons",
+        description: "Run the optional Uploadcare processing APIs from small, focused forms.",
         links: [
           [ "Document conversion formats info", new_document_conversion_information_path ],
           [ "Convert document", new_document_conversion_path ],
@@ -27,6 +29,7 @@ class ExamplesController < ApplicationController
       },
       {
         title: "Metadata and webhooks",
+        description: "Manage file metadata and webhook configuration through request-backed pages.",
         links: [
           [ "Metadata", file_metadata_path ],
           [ "Webhooks", webhooks_path ],
@@ -35,6 +38,7 @@ class ExamplesController < ApplicationController
       },
       {
         title: "Model and storage integrations",
+        description: "Try Active Record, Mongoid, and Active Storage examples that use Uploadcare-backed files.",
         links: [
           [ "Posts (ActiveRecord)", posts_path ],
           [ "Comments (Mongoid)", comments_path ],
@@ -43,6 +47,7 @@ class ExamplesController < ApplicationController
       },
       {
         title: "Uploader field helper APIs",
+        description: "Compare model-backed helpers with standalone tag helpers for uploader fields.",
         links: [
           [ "Uploader helper examples", uploader_fields_examples_path ]
         ]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,14 +2,25 @@
 
 module ApplicationHelper
   FLASH = {
-    "notice" => "alert alert-info",
-    "success" => "alert alert-success",
-    "error" => "alert alert-error",
-    "alert" => "alert alert-warning"
+    "notice" => "rounded-md border border-sky-200 bg-sky-50 px-4 py-3 text-sm text-sky-900",
+    "success" => "rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900",
+    "error" => "rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900",
+    "alert" => "rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
   }.freeze
 
   def flash_class(level)
     FLASH.with_indifferent_access[level]
+  end
+
+  def sidebar_link_class(active)
+    [
+      "block rounded-md px-3 py-2 text-sm font-medium transition",
+      active ? "bg-slate-900 text-white" : "text-slate-700 hover:bg-slate-100 hover:text-slate-950"
+    ].join(" ")
+  end
+
+  def sidebar_section_class
+    "px-3 pt-5 pb-2 text-xs font-semibold uppercase tracking-wide text-slate-500"
   end
 
   def format_date(date, format: "%B %e, %Y %H:%M")

--- a/app/views/active_storage_posts/index.html.erb
+++ b/app/views/active_storage_posts/index.html.erb
@@ -19,7 +19,7 @@
         </div>
         <div class="btn-group" role="group" aria-label="Actions">
           <%= link_to "Edit", edit_active_storage_post_path(active_storage_post), class: "btn btn-secondary btn-sm" %>
-          <%= link_to "Delete", active_storage_post_path(active_storage_post), method: :delete, class: "btn btn-danger btn-sm" %>
+          <%= button_to "Delete", active_storage_post_path(active_storage_post), method: :delete, class: "btn btn-danger btn-sm" %>
         </div>
       </li>
     <% end %>

--- a/app/views/active_storage_posts/show.html.erb
+++ b/app/views/active_storage_posts/show.html.erb
@@ -2,7 +2,7 @@
   Active Storage post "<%= @active_storage_post.title %>"
   <div class="d-inline mr-0">
     <%= link_to "Edit", edit_active_storage_post_path(@active_storage_post), class: "btn btn-secondary" %>
-    <%= link_to "Delete", active_storage_post_path(@active_storage_post), method: :delete, class: "btn btn-danger" %>
+    <%= button_to "Delete", active_storage_post_path(@active_storage_post), method: :delete, class: "btn btn-danger" %>
   </div>
 </h1>
 

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -8,7 +8,7 @@
         </div>
         <div class="btn-group" role="group" aria-label="Actions">
           <%= link_to 'Edit', edit_comment_path(comment), class: "btn btn-secondary btn-sm" %>
-          <%= link_to 'Delete', comment_path(comment), method: :delete, class: "btn btn-danger btn-sm" %>
+          <%= button_to 'Delete', comment_path(comment), method: :delete, class: "btn btn-danger btn-sm" %>
         </div>
       </li>
     <% end %>

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -2,7 +2,7 @@
   Comment "<%= @comment.content %>"
   <div class="d-inline mr-0">
     <%= link_to 'Edit', edit_comment_path(@comment), class: "btn btn-secondary" %>
-    <%= link_to 'Delete', comment_path(@comment), method: :delete, class: "btn btn-danger" %>
+    <%= button_to 'Delete', comment_path(@comment), method: :delete, class: "btn btn-danger" %>
   </div>
 </h1>
 
@@ -18,9 +18,9 @@
       <div class="badge badge-secondary"><%= @comment.image.mime_type %></div>
     </div>
     <div class="btn-group" role="group" aria-label="Actions">
-      <%= link_to 'Copy', copy_file_path(@comment.image.uuid), method: :post, class: "btn btn-secondary btn-sm" %>
-      <%= link_to 'Store', store_file_path(@comment.image.uuid), method: :post, class: "btn btn-secondary btn-sm" %>
-      <%= link_to 'Delete', file_path(@comment.image.uuid), method: :delete, class: "btn btn-danger btn-sm" %>
+      <%= button_to 'Copy', copy_file_path(@comment.image.uuid), method: :post, class: "btn btn-secondary btn-sm" %>
+      <%= button_to 'Store', store_file_path(@comment.image.uuid), method: :post, class: "btn btn-secondary btn-sm" %>
+      <%= button_to 'Delete', file_path(@comment.image.uuid), method: :delete, class: "btn btn-danger btn-sm" %>
     </div>
   </li>
 <% else %>
@@ -40,9 +40,9 @@
         <div class="badge badge-secondary"><%= file.mime_type %></div>
       </div>
       <div class="btn-group" role="group" aria-label="Actions">
-        <%= link_to 'Copy', copy_file_path(file.uuid), method: :post, class: "btn btn-secondary btn-sm" %>
-        <%= link_to 'Store', store_file_path(file.uuid), method: :post, class: "btn btn-secondary btn-sm" %>
-        <%= link_to 'Delete', file_path(file.uuid), method: :delete, class: "btn btn-danger btn-sm" %>
+        <%= button_to 'Copy', copy_file_path(file.uuid), method: :post, class: "btn btn-secondary btn-sm" %>
+        <%= button_to 'Store', store_file_path(file.uuid), method: :post, class: "btn btn-secondary btn-sm" %>
+        <%= button_to 'Delete', file_path(file.uuid), method: :delete, class: "btn btn-danger btn-sm" %>
       </div>
     </li>
   <% end %>

--- a/app/views/examples/index.html.erb
+++ b/app/views/examples/index.html.erb
@@ -1,19 +1,32 @@
-<h1>Examples</h1>
-<p class="text-body-secondary">Feature coverage grouped by practical Uploadcare workflows.</p>
+<div class="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+  <div>
+    <h1>Examples</h1>
+    <p class="page-lede">Feature coverage grouped by practical Uploadcare workflows. Each page stays close to standard Rails controllers, views, forms, Turbo navigation, and request specs.</p>
+  </div>
 
-<div class="row row-cols-1 row-cols-lg-2 g-3">
+  <%= link_to "Uploader helpers", uploader_fields_examples_path, class: "btn btn-primary" %>
+</div>
+
+<div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
   <% @example_groups.each do |group| %>
-    <div class="col">
-      <div class="card h-100">
-        <div class="card-body">
-          <h2 class="h5 card-title"><%= group[:title] %></h2>
-          <ul class="mb-0">
-            <% group[:links].each do |label, path| %>
-              <li><%= link_to label, path %></li>
-            <% end %>
-          </ul>
+    <article class="card h-full">
+      <div class="card-body flex h-full flex-col">
+        <div class="mb-4">
+          <h2 class="text-base font-semibold text-slate-950"><%= group[:title] %></h2>
+          <p class="mt-1 text-sm leading-6 text-slate-600"><%= group[:description] %></p>
         </div>
+
+        <ul class="mt-auto divide-y divide-slate-100">
+          <% group[:links].each do |label, path| %>
+            <li>
+              <%= link_to path, class: "flex items-center justify-between gap-3 py-2 text-sm font-medium text-slate-700 no-underline hover:text-slate-950" do %>
+                <span><%= label %></span>
+                <span aria-hidden="true" class="text-slate-400">-&gt;</span>
+              <% end %>
+            </li>
+          <% end %>
+        </ul>
       </div>
-    </div>
+    </article>
   <% end %>
 </div>

--- a/app/views/examples/uploader_fields.html.erb
+++ b/app/views/examples/uploader_fields.html.erb
@@ -1,51 +1,47 @@
 <h1>Uploader Helper Examples</h1>
 
-<p class="text-body-secondary">
+<p class="page-lede">
   This page demonstrates the helper APIs from <code>uploadcare-rails</code> without adding CDN-only flows.
 </p>
 
-<div class="row row-cols-1 row-cols-lg-2 g-3">
-  <div class="col">
-    <div class="card h-100">
-      <div class="card-body">
-        <h2 class="h5 card-title">Model-backed helpers</h2>
+<div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
+  <div class="card h-full">
+    <div class="card-body">
+      <h2 class="h5 card-title">Model-backed helpers</h2>
 
-        <%= form_with model: @post, url: uploader_fields_examples_path, method: :post do |f| %>
-          <div class="mb-3">
-            <%= f.label :logo, "Single file (uploadcare_file_field)" %>
-            <%= f.uploadcare_file_field :logo, solution: "regular", img_only: true %>
-          </div>
+      <%= form_with model: @post, url: uploader_fields_examples_path, method: :post do |f| %>
+        <div class="mb-3">
+          <%= f.label :logo, "Single file (uploadcare_file_field)" %>
+          <%= f.uploadcare_file_field :logo, solution: "regular", img_only: true %>
+        </div>
 
-          <div class="mb-3">
-            <%= f.label :attachments, "Grouped files (uploadcare_files_field)" %>
-            <%= f.uploadcare_files_field :attachments, solution: "regular" %>
-          </div>
+        <div class="mb-3">
+          <%= f.label :attachments, "Grouped files (uploadcare_files_field)" %>
+          <%= f.uploadcare_files_field :attachments, solution: "regular" %>
+        </div>
 
-          <%= f.submit "Submit model-backed values", class: "btn btn-primary" %>
-        <% end %>
-      </div>
+        <%= f.submit "Submit model-backed values", class: "btn btn-primary" %>
+      <% end %>
     </div>
   </div>
 
-  <div class="col">
-    <div class="card h-100">
-      <div class="card-body">
-        <h2 class="h5 card-title">Standalone tag helpers</h2>
+  <div class="card h-full">
+    <div class="card-body">
+      <h2 class="h5 card-title">Standalone tag helpers</h2>
 
-        <%= form_with url: uploader_fields_examples_path, method: :post do %>
-          <div class="mb-3">
-            <%= label_tag :standalone_logo, "Single file (uploadcare_file_field_tag)" %>
-            <%= uploadcare_file_field_tag :standalone_logo, solution: "regular", img_only: true %>
-          </div>
+      <%= form_with url: uploader_fields_examples_path, method: :post do %>
+        <div class="mb-3">
+          <%= label_tag :standalone_logo, "Single file (uploadcare_file_field_tag)" %>
+          <%= uploadcare_file_field_tag :standalone_logo, solution: "regular", img_only: true %>
+        </div>
 
-          <div class="mb-3">
-            <%= label_tag :standalone_attachments, "Grouped files (uploadcare_files_field_tag)" %>
-            <%= uploadcare_files_field_tag :standalone_attachments, solution: "regular" %>
-          </div>
+        <div class="mb-3">
+          <%= label_tag :standalone_attachments, "Grouped files (uploadcare_files_field_tag)" %>
+          <%= uploadcare_files_field_tag :standalone_attachments, solution: "regular" %>
+        </div>
 
-          <%= submit_tag "Submit standalone values", class: "btn btn-outline-primary" %>
-        <% end %>
-      </div>
+        <%= submit_tag "Submit standalone values", class: "btn btn-outline-primary" %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/file_groups/show.html.erb
+++ b/app/views/file_groups/show.html.erb
@@ -17,8 +17,10 @@
     <strong>URL</strong>: <%= @file_group.url %>
   </li>
   <li class="list-group-item">
-    <%= link_to 'Delete', file_group_path(@file_group.id), method: :delete, class: 'btn btn-sm btn-danger' %>
-    <%= link_to 'Store', store_file_group_path(@file_group.id), method: :post, class: 'btn btn-sm btn-secondary' %>
+    <div class="btn-group">
+      <%= button_to 'Delete', file_group_path(@file_group.id), method: :delete, class: 'btn btn-sm btn-danger' %>
+      <%= button_to 'Store', store_file_group_path(@file_group.id), method: :post, class: 'btn btn-sm btn-secondary' %>
+    </div>
   </li>
 </ul>
 <h5 class="mt-3">Files</h5>
@@ -31,9 +33,9 @@
       <div class="badge badge-secondary"><%= file.mime_type %></div>
     </div>
     <div class="btn-group" role="group" aria-label="Actions">
-      <%= link_to 'Copy', copy_file_path(file.uuid), method: :post, class: "btn btn-secondary btn-sm" %>
-      <%= link_to 'Store', store_file_path(file.uuid), method: :post, class: 'btn btn-secondary btn-sm' %>
-      <%= link_to 'Delete', file_path(file.uuid), method: :delete, class: 'btn btn-danger btn-sm' %>
+      <%= button_to 'Copy', copy_file_path(file.uuid), method: :post, class: "btn btn-secondary btn-sm" %>
+      <%= button_to 'Store', store_file_path(file.uuid), method: :post, class: 'btn btn-secondary btn-sm' %>
+      <%= button_to 'Delete', file_path(file.uuid), method: :delete, class: 'btn btn-danger btn-sm' %>
     </div>
   </li>
 <% end %>

--- a/app/views/files/_file_list_table.html.erb
+++ b/app/views/files/_file_list_table.html.erb
@@ -19,9 +19,9 @@
           <div class="badge badge-secondary"><%= file.mime_type %></div>
         </div>
         <div class="btn-group" role="group" aria-label="Actions">
-          <%= link_to 'Copy', copy_file_path(file.uuid), method: :post, class: "btn btn-secondary btn-sm" %>
-          <%= link_to 'Store', store_file_path(file.uuid), method: :post, class: "btn btn-secondary btn-sm" %>
-          <%= link_to 'Delete', file_path(file.uuid), method: :delete, class: "btn btn-danger btn-sm" %>
+          <%= button_to 'Copy', copy_file_path(file.uuid), method: :post, class: "btn btn-secondary btn-sm" %>
+          <%= button_to 'Store', store_file_path(file.uuid), method: :post, class: "btn btn-secondary btn-sm" %>
+          <%= button_to 'Delete', file_path(file.uuid), method: :delete, class: "btn btn-danger btn-sm" %>
         </div>
       </li>
     <% end %>

--- a/app/views/files/show.html.erb
+++ b/app/views/files/show.html.erb
@@ -3,9 +3,9 @@
   <hr>
   <h4 class="d-flex justify-content-between align-items-center">
     Remote file
-    <div>
-      <%= link_to 'Copy', copy_file_path(@file.uuid), method: :post, class: "btn btn-secondary" %>
-      <%= link_to 'Store', store_file_path(@file.uuid), method: :post, class: "btn btn-secondary" %>
+    <div class="btn-group">
+      <%= button_to 'Copy', copy_file_path(@file.uuid), method: :post, class: "btn btn-secondary" %>
+      <%= button_to 'Store', store_file_path(@file.uuid), method: :post, class: "btn btn-secondary" %>
     </div>
   </h4>
   <div class="table-responsive">
@@ -19,4 +19,4 @@
   <% if @file.content_info&.dig("video").present? || @file.content_info&.dig(:video).present? %>
     <%= render 'files/video_info', video_info: (@file.content_info["video"] || @file.content_info[:video]) %>
   <% end %>
-  <%= link_to 'Delete file', file_path(@file.uuid), method: :delete, class: "btn btn-danger" %>
+  <%= button_to 'Delete file', file_path(@file.uuid), method: :delete, class: "btn btn-danger" %>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,12 +1,12 @@
 <% flash.each do |key, value| %>
   <% if value.is_a? Array %>
     <% value.each do |element| %>
-      <div class="<%= "#{flash_class(key) || ('alert alert-' + key)}" %>"
+      <div class="<%= flash_class(key) || "rounded-md border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900" %>">
         <%= element %>
       </div>
     <% end %>
   <% else %>
-    <div class="<%= "#{flash_class(key) || ('alert alert-' + key)}" %>" >
+    <div class="<%= flash_class(key) || "rounded-md border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900" %>" >
       <%= value %>
     </div>
   <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,0 +1,16 @@
+<header class="border-b border-slate-200 bg-white">
+  <div class="mx-auto flex max-w-7xl items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:px-8">
+    <%= link_to root_path, class: "flex items-center gap-3 text-slate-950" do %>
+      <span class="flex h-9 w-9 items-center justify-center rounded-md bg-slate-950 text-sm font-semibold text-white">UC</span>
+      <span>
+        <span class="block text-sm font-semibold leading-5">Uploadcare Rails</span>
+        <span class="block text-xs text-slate-500">Examples for Rails, Turbo, and Active Storage</span>
+      </span>
+    <% end %>
+
+    <div class="flex items-center gap-3">
+      <%= link_to "Examples", examples_path, class: "hidden rounded-md px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 hover:text-slate-950 sm:inline-flex" %>
+      <%= link_to "Docs", "https://uploadcare.com/docs/", class: "rounded-md bg-slate-950 px-3 py-2 text-sm font-medium text-white hover:bg-slate-800", target: "_blank", rel: "noopener" %>
+    </div>
+  </div>
+</header>

--- a/app/views/layouts/_menu.html.erb
+++ b/app/views/layouts/_menu.html.erb
@@ -1,91 +1,35 @@
-<ul class="nav nav-pills flex-column">
-  <li class="nav-item px-3 pt-1 small text-body-secondary">Examples</li>
-  <li class="nav-item">
-    <%= link_to "Examples overview", examples_path, class: "nav-link #{controller_name == 'examples' && action_name == 'index' ? 'active' : ''}" %>
-  </li>
-  <li class="nav-item">
-    <%= link_to "Uploader helper examples", uploader_fields_examples_path, class: "nav-link #{controller_name == 'examples' && action_name == 'uploader_fields' ? 'active' : ''}" %>
-  </li>
+<nav aria-label="Examples navigation" class="space-y-1">
+  <div class="<%= sidebar_section_class %>">Examples</div>
+  <%= link_to "Examples overview", examples_path, class: sidebar_link_class(controller_name == "examples" && action_name == "index"), aria: { current: (controller_name == "examples" && action_name == "index" ? "page" : nil) } %>
+  <%= link_to "Uploader helper examples", uploader_fields_examples_path, class: sidebar_link_class(controller_name == "examples" && action_name == "uploader_fields"), aria: { current: (controller_name == "examples" && action_name == "uploader_fields" ? "page" : nil) } %>
 
-  <li class="dropdown-divider"></li>
-  <li class="nav-item px-3 pt-1 small text-body-secondary">Core API operations</li>
+  <div class="<%= sidebar_section_class %>">Core API operations</div>
+  <%= link_to "Project info", project_path, class: sidebar_link_class(controller_name == "projects") %>
+  <%= link_to "Files", files_path, class: sidebar_link_class(controller_name == "files") %>
+  <%= link_to "File groups", file_groups_path, class: sidebar_link_class(controller_name == "file_groups" && %w[index show].include?(action_name)) %>
+  <%= link_to "Create file group", new_file_group_path, class: sidebar_link_class(controller_name == "file_groups" && action_name == "new") %>
+  <%= link_to "Upload local file", upload_new_local_file_path, class: sidebar_link_class(controller_name == "uploads" && action_name == "new_local") %>
+  <%= link_to "Upload file from URL", upload_new_file_from_url_path, class: sidebar_link_class(controller_name == "uploads" && action_name == "new_from_url") %>
 
-  <li class="nav-item">
-    <%= link_to "Project info", project_path, class: "nav-link #{controller_name == 'projects' ? 'active' : ''}" %>
-  </li>
-  <li class="nav-item">
-    <%= link_to "Files", files_path, class: "nav-link #{controller_name == 'files' ? 'active' : ''}" %>
-  </li>
-  <li class="nav-item">
-    <%= link_to "File groups", file_groups_path, class: "nav-link #{controller_name == 'file_groups' && %w[index show].include?(action_name) ? 'active' : ''}" %>
-  </li>
-  <li class="nav-item">
-    <%= link_to "Create file group", new_file_group_path, class: "nav-link #{controller_name == 'file_groups' && action_name == 'new' ? 'active' : ''}" %>
-  </li>
-  <li class="nav-item">
-    <%= link_to "Upload local file", upload_new_local_file_path, class: "nav-link #{controller_name == 'uploads' && action_name == 'new_local' ? 'active' : ''}" %>
-  </li>
-  <li class="nav-item">
-    <%= link_to "Upload file from URL", upload_new_file_from_url_path, class: "nav-link #{controller_name == 'uploads' && action_name == 'new_from_url' ? 'active' : ''}" %>
-  </li>
+  <div class="<%= sidebar_section_class %>">Conversions and add-ons</div>
+  <%= link_to "Document conversion formats info", new_document_conversion_information_path, class: sidebar_link_class(controller_name == "document_conversion_information") %>
+  <%= link_to "Convert document", new_document_conversion_path, class: sidebar_link_class(controller_name == "document_conversions") %>
+  <%= link_to "Convert video", new_video_conversion_path, class: sidebar_link_class(controller_name == "video_conversions") %>
+  <%= link_to "Virus scan", new_virus_scan_path, class: sidebar_link_class(controller_name == "virus_scan") %>
+  <%= link_to "Rekognition labels", new_rekognition_label_path, class: sidebar_link_class(controller_name == "rekognition_labels") %>
+  <%= link_to "Remove bg", new_remove_bg_path, class: sidebar_link_class(controller_name == "remove_bg") %>
+  <%= link_to "Rekognition moderation labels", new_rekognition_moderation_label_path, class: sidebar_link_class(controller_name == "rekognition_moderation_labels") %>
 
-  <li class="dropdown-divider"></li>
-  <li class="nav-item px-3 pt-1 small text-body-secondary">Conversions and add-ons</li>
+  <div class="<%= sidebar_section_class %>">Metadata and webhooks</div>
+  <%= link_to "Metadata", file_metadata_path, class: sidebar_link_class(controller_name == "file_metadata") %>
+  <%= link_to "Webhooks", webhooks_path, class: sidebar_link_class(controller_name == "webhooks" && %w[index show].include?(action_name)) %>
+  <%= link_to "Create webhook", new_webhook_path, class: sidebar_link_class(controller_name == "webhooks" && action_name == "new") %>
 
-  <li class="nav-item">
-    <%= link_to "Document conversion formats info", new_document_conversion_information_path, class: "nav-link #{controller_name == 'document_conversion_information' ? 'active' : ''}" %>
-  </li>
-  <li class="nav-item">
-    <%= link_to "Convert document", new_document_conversion_path, class: "nav-link #{controller_name == 'document_conversions' ? 'active' : ''}" %>
-  </li>
-  <li class="nav-item">
-    <%= link_to "Convert video", new_video_conversion_path, class: "nav-link #{controller_name == 'video_conversions' ? 'active' : ''}" %>
-  </li>
-  <li class="nav-item">
-    <%= link_to "Virus scan", new_virus_scan_path, class: "nav-link #{controller_name == 'virus_scan' ? 'active' : ''}" %>
-  </li>
-  <li class="nav-item">
-    <%= link_to "Rekognition labels", new_rekognition_label_path, class: "nav-link #{controller_name == 'rekognition_labels' ? 'active' : ''}" %>
-  </li>
-  <li class="nav-item">
-    <%= link_to "Remove bg", new_remove_bg_path, class: "nav-link #{controller_name == 'remove_bg' ? 'active' : ''}" %>
-  </li>
-  <li class="nav-item">
-    <%= link_to "Rekognition moderation labels", new_rekognition_moderation_label_path, class: "nav-link #{controller_name == 'rekognition_moderation_labels' ? 'active' : ''}" %>
-  </li>
-
-  <li class="dropdown-divider"></li>
-  <li class="nav-item px-3 pt-1 small text-body-secondary">Metadata and webhooks</li>
-
-  <li class="nav-item">
-    <%= link_to "Metadata", file_metadata_path, class: "nav-link #{controller_name == 'file_metadata' ? 'active' : ''}" %>
-  </li>
-  <li class="nav-item">
-    <%= link_to "Webhooks", webhooks_path, class: "nav-link #{controller_name == 'webhooks' && %w[index show].include?(action_name) ? 'active' : ''}" %>
-  </li>
-  <li class="nav-item">
-    <%= link_to "Create webhook", new_webhook_path, class: "nav-link #{controller_name == 'webhooks' && action_name == 'new' ? 'active' : ''}" %>
-  </li>
-
-  <li class="dropdown-divider"></li>
-  <li class="nav-item px-3 pt-1 small text-body-secondary">Model and storage integrations</li>
-
-  <li class="nav-item">
-    <%= link_to "Posts", posts_path, class: "nav-link #{controller_name == 'posts' && %w[index show].include?(action_name) ? 'active' : ''}" %>
-  </li>
-  <li class="nav-item">
-    <%= link_to "Create post", new_post_path, class: "nav-link #{controller_name == 'posts' && action_name == 'new' ? 'active' : ''}" %>
-  </li>
-  <li class="nav-item">
-    <%= link_to "Active Storage posts", active_storage_posts_path, class: "nav-link #{controller_name == 'active_storage_posts' && %w[index show].include?(action_name) ? 'active' : ''}" %>
-  </li>
-  <li class="nav-item">
-    <%= link_to "Create Active Storage post", new_active_storage_post_path, class: "nav-link #{controller_name == 'active_storage_posts' && action_name == 'new' ? 'active' : ''}" %>
-  </li>
-  <li class="nav-item">
-    <%= link_to "Comments (Mongoid)", comments_path, class: "nav-link #{controller_name == 'comments' && %w[index show].include?(action_name) ? 'active' : ''}" %>
-  </li>
-  <li class="nav-item">
-    <%= link_to "Create comment", new_comment_path, class: "nav-link #{controller_name == 'comments' && action_name == 'new' ? 'active' : ''}" %>
-  </li>
-</ul>
+  <div class="<%= sidebar_section_class %>">Model and storage integrations</div>
+  <%= link_to "Posts", posts_path, class: sidebar_link_class(controller_name == "posts" && %w[index show].include?(action_name)) %>
+  <%= link_to "Create post", new_post_path, class: sidebar_link_class(controller_name == "posts" && action_name == "new") %>
+  <%= link_to "Active Storage posts", active_storage_posts_path, class: sidebar_link_class(controller_name == "active_storage_posts" && %w[index show].include?(action_name)) %>
+  <%= link_to "Create Active Storage post", new_active_storage_post_path, class: sidebar_link_class(controller_name == "active_storage_posts" && action_name == "new") %>
+  <%= link_to "Comments (Mongoid)", comments_path, class: sidebar_link_class(controller_name == "comments" && %w[index show].include?(action_name)) %>
+  <%= link_to "Create comment", new_comment_path, class: sidebar_link_class(controller_name == "comments" && action_name == "new") %>
+</nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,38 +7,32 @@
     <%= csp_meta_tag %>
 
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbo-track': 'reload' %>
+    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "application", media: "all", "data-turbo-track": "reload" %>
     <%= uploadcare_include_tag min: true %>
-
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.1/css/bootstrap.min.css"
-        integrity="sha384-VCmXjywReHh4PwowAiWNagnWcLhlEJLA5buUprzK8rxFgeH0kww/aWY76TfkUoSX" crossorigin="anonymous">
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
-          integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
-          crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"
-          integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN"
-          crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.1/js/bootstrap.min.js"
-          integrity="sha384-XEerZL0cuoUbHE4nZReLT7nx9gQrQreJekYhJD9WNWhH8nEW+0c5qq7aIo2Wl30J"
-          crossorigin="anonymous"></script>
-
   </head>
 
-  <body class="mb-5">
-    <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
-      <a class="navbar-brand" href="https://uploadcare.com" target="_blank">Uploadcare</a>
-    </nav>
+  <body class="min-h-screen bg-slate-50 text-slate-900 antialiased">
+    <%= render "layouts/header" %>
 
-    <div class="container-fluid">
-      <div class="row">
-        <aside class="col-sm-3">
-          <%= render 'layouts/menu' %>
+    <div class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+      <details class="mb-4 rounded-md border border-slate-200 bg-white p-3 shadow-sm lg:hidden">
+        <summary class="cursor-pointer text-sm font-semibold text-slate-900">Navigation</summary>
+        <div class="mt-3 border-t border-slate-100 pt-3">
+          <%= render "layouts/menu" %>
+        </div>
+      </details>
+
+      <div class="grid gap-6 lg:grid-cols-[18rem_minmax(0,1fr)]">
+        <aside class="hidden self-start rounded-md border border-slate-200 bg-white p-3 shadow-sm lg:block">
+          <%= render "layouts/menu" %>
         </aside>
-        <main class="col-sm-9">
-          <div class="container w-100">
-            <%= render 'layouts/flash', flash: flash, allowed_keys: ApplicationHelper::FLASH.keys %>
+
+        <main class="min-w-0 space-y-5">
+          <%= render "layouts/flash", flash: flash, allowed_keys: ApplicationHelper::FLASH.keys %>
+          <section class="rounded-md border border-slate-200 bg-white p-5 shadow-sm sm:p-6">
             <%= yield %>
-          </div>
+          </section>
         </main>
       </div>
     </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -8,7 +8,7 @@
         </div>
         <div class="btn-group" role="group" aria-label="Actions">
           <%= link_to 'Edit', edit_post_path(post), class: "btn btn-secondary btn-sm" %>
-          <%= link_to 'Delete', post_path(post), method: :delete, class: "btn btn-danger btn-sm" %>
+          <%= button_to 'Delete', post_path(post), method: :delete, class: "btn btn-danger btn-sm" %>
         </div>
       </li>
     <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -2,7 +2,7 @@
   Post "<%= short_title(@post) %>"
   <div class="d-inline mr-0">
     <%= link_to 'Edit', edit_post_path(@post), class: "btn btn-secondary" %>
-    <%= link_to 'Delete', post_path(@post), method: :delete, class: "btn btn-danger" %>
+    <%= button_to 'Delete', post_path(@post), method: :delete, class: "btn btn-danger" %>
   </div>
 </h1>
 
@@ -18,9 +18,9 @@
       <div class="badge badge-secondary"><%= @post.logo.mime_type %></div>
     </div>
     <div class="btn-group" role="group" aria-label="Actions">
-      <%= link_to 'Copy', copy_file_path(@post.logo.uuid), method: :post, class: "btn btn-secondary btn-sm" %>
-      <%= link_to 'Store', store_file_path(@post.logo.uuid), method: :post, class: "btn btn-secondary btn-sm" %>
-      <%= link_to 'Delete', file_path(@post.logo.uuid), method: :delete, class: "btn btn-danger btn-sm" %>
+      <%= button_to 'Copy', copy_file_path(@post.logo.uuid), method: :post, class: "btn btn-secondary btn-sm" %>
+      <%= button_to 'Store', store_file_path(@post.logo.uuid), method: :post, class: "btn btn-secondary btn-sm" %>
+      <%= button_to 'Delete', file_path(@post.logo.uuid), method: :delete, class: "btn btn-danger btn-sm" %>
     </div>
   </li>
 <% else %>
@@ -40,9 +40,9 @@
         <div class="badge badge-secondary"><%= file.mime_type %></div>
       </div>
       <div class="btn-group" role="group" aria-label="Actions">
-        <%= link_to 'Copy', copy_file_path(file.uuid), method: :post, class: "btn btn-secondary btn-sm" %>
-        <%= link_to 'Store', store_file_path(file.uuid), method: :post, class: "btn btn-secondary btn-sm" %>
-        <%= link_to 'Delete', file_path(file.uuid), method: :delete, class: "btn btn-danger btn-sm" %>
+        <%= button_to 'Copy', copy_file_path(file.uuid), method: :post, class: "btn btn-secondary btn-sm" %>
+        <%= button_to 'Store', store_file_path(file.uuid), method: :post, class: "btn btn-secondary btn-sm" %>
+        <%= button_to 'Delete', file_path(file.uuid), method: :delete, class: "btn btn-danger btn-sm" %>
       </div>
     </li>
   <% end %>

--- a/app/views/webhooks/index.html.erb
+++ b/app/views/webhooks/index.html.erb
@@ -9,7 +9,7 @@
       </div>
       <div class="btn-group" role="group" aria-label="Actions">
         <%= link_to 'Edit', edit_webhook_path(webhook.id), class: 'btn btn-sm btn-secondary' %>
-        <%= link_to 'Delete', delete_webhook_path(target_url: webhook.target_url), method: :delete, class: 'btn btn-sm btn-danger' %>
+        <%= button_to 'Delete', delete_webhook_path(target_url: webhook.target_url), method: :delete, class: 'btn btn-sm btn-danger' %>
       </div>
     </li>
   <% end %>

--- a/app/views/webhooks/show.html.erb
+++ b/app/views/webhooks/show.html.erb
@@ -1,6 +1,6 @@
 <h1>Webhook ID <%= @webhook.id %> info
   <%= link_to 'Edit', edit_webhook_path(@webhook.id), class: 'btn btn-sm btn-secondary' %>
-  <%= link_to 'Delete', delete_webhook_path(target_url: @webhook.target_url), method: :delete, class: 'btn btn-sm btn-danger' %>
+  <%= button_to 'Delete', delete_webhook_path(target_url: @webhook.target_url), method: :delete, class: 'btn btn-sm btn-danger' %>
 </h1>
 
 <div class="card">

--- a/bin/ci
+++ b/bin/ci
@@ -15,6 +15,7 @@ chdir APP_ROOT do
   system! 'mise exec -- bundle install'
   system! 'mise exec -- pnpm install'
   system! 'mise exec -- pnpm build'
+  system! 'mise exec -- ruby bin/rails tailwindcss:build'
   system! 'mise exec -- bundle exec rubocop'
   system! 'mise exec -- bundle exec rails_best_practices'
   system! 'mise exec -- brakeman'

--- a/spec/requests/examples_controller_spec.rb
+++ b/spec/requests/examples_controller_spec.rb
@@ -8,8 +8,11 @@ RSpec.describe ExamplesController, type: :request do
       get "/examples"
 
       expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Uploadcare Rails")
+      expect(response.body).to include("tailwind")
       expect(response.body).to include("Core API operations")
       expect(response.body).to include("Uploader field helper APIs")
+      expect(response.body).not_to include("stackpath.bootstrapcdn.com/bootstrap")
     end
   end
 

--- a/spec/system/examples_spec.rb
+++ b/spec/system/examples_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Examples", type: :system do
     visit "/examples"
 
     expect(page).to have_text("Examples")
+    expect(page).to have_text("Navigation")
     expect(page).to have_text("Core API operations")
     expect(page).to have_text("Conversions and add-ons")
     expect(page).to have_text("Uploader field helper APIs")


### PR DESCRIPTION
## Summary
- switch Uploadcare dependencies to the published 5.0.0.rc1 prerelease gems
- add Rails-native Tailwind CSS and replace the Bootstrap/jQuery shell with Tailwind layout partials
- refresh the examples overview, sidebar, flashes, and common state-changing actions for Hotwire-friendly Rails patterns
- update README and examples coverage for the new shell

## Verification
- bin/ci passes locally: bundle install, pnpm install/build, tailwindcss:build, rubocop, rails_best_practices, brakeman, rspec
- rspec: 122 examples, 0 failures
- browser smoke checked /examples at desktop and mobile viewport sizes